### PR TITLE
Added magnetometer interrupt handler for driver

### DIFF
--- a/src/josh.h
+++ b/src/josh.h
@@ -122,6 +122,12 @@
   (GPIO_INPUT | GPIO_FLOAT | GPIO_EXTI | GPIO_SPEED_100MHz | GPIO_PORTE |      \
    GPIO_PIN1)
 
+/* Magnetometer interrupt pin */
+
+#define GPIO_MAG_INT                                                           \
+  (GPIO_INPUT | GPIO_FLOAT | GPIO_EXTI | GPIO_SPEED_100MHz | GPIO_PORTD |      \
+   GPIO_PIN15)
+
 /* Buzzer
  * Josh has an arming buzzer to indicate when it is armed and running.
  */


### PR DESCRIPTION
Closes #11.

Tested on Josh Rev B. On Rev A this will not work, disable the `CONFIG_SCHED_HPWORK` queue so that it uses kernel thread polling instead.